### PR TITLE
ci: add build:dev script for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"type-check:watch": "npm run type-check -- --watch",
 		"lint": "eslint --ext .js,.jsx,.ts,.tsx --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
 		"pull-translations": "git subtree pull -P translations git@github.com:zextras/carbonio-auth-ui-i18n.git master --squash",
-		"push-translations": "git subtree push -P translations git@github.com:zextras/carbonio-auth-ui-i18n.git"
+		"push-translations": "git subtree push -P translations git@github.com:zextras/carbonio-auth-ui-i18n.git",
+		"build:dev": "sdk build --dev --pkgRel $(date +%s)"
 	},
 	"keywords": [],
 	"license": "ISC",


### PR DESCRIPTION
To make common pipeline support different bundlers, we need to remove references to the sdk from it and move them inside projects scripts. build:dev is the script in charge of creating the build in dev mode. Related to zextras/jenkins-zapp-lib#13