### PR TITLE
refactor: [CO-1575] partial ts conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
 				"@babel/preset-typescript": "^7.24.1",
 				"@commitlint/cli": "^19.2.1",
 				"@commitlint/config-conventional": "^19.1.0",
+				"@testing-library/jest-dom": "^5.16.5",
+				"@testing-library/react": "^16.0.1",
 				"@types/jest": "^28.1.6",
 				"@types/lodash": "^4.17.0",
 				"@zextras/carbonio-ui-configs": "^1.0.0",
@@ -55,6 +57,12 @@
 				"node": "v18",
 				"npm": "v10"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
+			"integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
+			"dev": true
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
@@ -4208,6 +4216,263 @@
 				"@sinonjs/commons": "^3.0.0"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+			"integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/@testing-library/dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/@testing-library/dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "5.17.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
+			"integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
+			"dev": true,
+			"dependencies": {
+				"@adobe/css-tools": "^4.0.1",
+				"@babel/runtime": "^7.9.2",
+				"@types/testing-library__jest-dom": "^5.9.1",
+				"aria-query": "^5.0.0",
+				"chalk": "^3.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.5.6",
+				"lodash": "^4.17.15",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
+			"integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0",
+				"@types/react-dom": "^18.0.0",
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@tinymce/tinymce-react": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-4.3.2.tgz",
@@ -4229,6 +4494,13 @@
 			"engines": {
 				"node": ">= 10"
 			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4519,12 +4791,11 @@
 			"dev": true
 		},
 		"node_modules/@types/react": {
-			"version": "17.0.83",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
-			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+			"version": "18.3.11",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
+			"integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"@types/scheduler": "^0.16",
 				"csstype": "^3.0.2"
 			}
 		},
@@ -4537,7 +4808,10 @@
 		"node_modules/@types/scheduler": {
 			"version": "0.16.8",
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
+			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
@@ -4595,6 +4869,15 @@
 			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
 			"integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
 			"dev": true
+		},
+		"node_modules/@types/testing-library__jest-dom": {
+			"version": "5.14.9",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
+			"integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
+			"dev": true,
+			"dependencies": {
+				"@types/jest": "*"
+			}
 		},
 		"node_modules/@types/tough-cookie": {
 			"version": "4.0.5",
@@ -5521,6 +5804,19 @@
 			"engines": {
 				"node": ">=18.0.0 <19.0.0 || >=20.0.0 <21.0.0",
 				"npm": "v10"
+			}
+		},
+		"node_modules/@zextras/carbonio-ui-sdk/node_modules/@types/react": {
+			"version": "17.0.83",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
+			"integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/prop-types": "*",
+				"@types/scheduler": "^0.16",
+				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-sdk/node_modules/ansi-styles": {
@@ -7560,6 +7856,12 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7985,6 +8287,12 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true
 		},
 		"node_modules/dom-converter": {
 			"version": "0.2.0",
@@ -14760,6 +15068,16 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/make-cancellable-promise": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.3.2.tgz",
@@ -14979,6 +15297,15 @@
 			"dev": true,
 			"dependencies": {
 				"dom-walk": "^0.1.0"
+			}
+		},
+		"node_modules/min-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
@@ -16957,6 +17284,19 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"dependencies": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/redux": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
@@ -18008,6 +18348,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/strip-indent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dev": true,
+			"dependencies": {
+				"min-indent": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/strip-json-comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
 				"@testing-library/react": "^16.0.1",
 				"@types/jest": "^28.1.6",
 				"@types/lodash": "^4.17.0",
+				"@types/styled-components": "^5.1.34",
 				"@zextras/carbonio-ui-configs": "^1.0.0",
 				"@zextras/carbonio-ui-sdk": "^1.7.4",
 				"babel-plugin-styled-components": "1.13.3",
@@ -4869,6 +4870,17 @@
 			"resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
 			"integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
 			"dev": true
+		},
+		"node_modules/@types/styled-components": {
+			"version": "5.1.34",
+			"resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+			"integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
+			"dev": true,
+			"dependencies": {
+				"@types/hoist-non-react-statics": "*",
+				"@types/react": "*",
+				"csstype": "^3.0.2"
+			}
 		},
 		"node_modules/@types/testing-library__jest-dom": {
 			"version": "5.14.9",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@testing-library/react": "^16.0.1",
 		"@types/lodash": "^4.17.0",
 		"@types/jest": "^28.1.6",
+		"@types/styled-components": "^5.1.34",
 		"@zextras/carbonio-ui-configs": "^1.0.0",
 		"@zextras/carbonio-ui-sdk": "^1.7.4",
 		"babel-plugin-styled-components": "1.13.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
 		"@babel/preset-typescript": "^7.24.1",
 		"@commitlint/cli": "^19.2.1",
 		"@commitlint/config-conventional": "^19.1.0",
+		"@testing-library/jest-dom": "^5.16.5",
+		"@testing-library/react": "^16.0.1",
 		"@types/lodash": "^4.17.0",
 		"@types/jest": "^28.1.6",
 		"@zextras/carbonio-ui-configs": "^1.0.0",

--- a/src/jest-env-setup.js
+++ b/src/jest-env-setup.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import fetchMock from 'jest-fetch-mock';
+import '@testing-library/jest-dom';
 
 beforeEach(() => {
 	// Do not useFakeTimers with `whatwg-fetch` if using mocked server

--- a/src/settings/assets/icons/auth-outline.tsx
+++ b/src/settings/assets/icons/auth-outline.tsx
@@ -1,12 +1,12 @@
 /*
- * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
 import React from 'react';
 
-export function AuthOutline({ size = '4rem' }: { size: string }): React.JSX.Element {
+export function AuthOutline({ size = '4rem' }: { size?: string }): React.JSX.Element {
 	return (
 		<svg
 			width={size}

--- a/src/settings/assets/icons/auth-outline.tsx
+++ b/src/settings/assets/icons/auth-outline.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 
-export function AuthOutline({ size = '4rem' }) {
+export function AuthOutline({ size = '4rem' }: { size: string }): React.JSX.Element {
 	return (
 		<svg
 			width={size}

--- a/src/settings/auth-view.tsx
+++ b/src/settings/auth-view.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
@@ -17,6 +18,7 @@ import { ExchangeActiveSync } from './components/operations/exchange-active-sync
 import { OTPAuthentication } from './components/operations/otp-authentication';
 import { RecoveryPassword } from './components/operations/recovery-password';
 import { ResetPassword } from './components/operations/reset-password';
+// @ts-ignore
 import { ColumnFull, ColumnLeft, ColumnRight, Shell } from './components/shared/shell';
 import { SidebarNavigation } from './components/shared/sidebar-navigation';
 import { checkSupportedZextras } from './network/checkSupportedZextras';
@@ -157,6 +159,8 @@ function SideBar({
 
 	useEffect(() => {
 		setActiveTab(links[0]);
+		// putting depencency results in first tab to be always active
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	return (
@@ -222,7 +226,7 @@ export default function App(): React.JSX.Element {
 		checkHasZextras();
 	}, [checkHasZextras]);
 
-	const occupyFull = useMemo(() => window.innerWidth <= 1800, [window.innerWidth]);
+	const occupyFull = useMemo(() => window.innerWidth <= 1800, []);
 	return (
 		<Shell>
 			<SideBar activeTab={activeTab} setActiveTab={setActiveTab} hasZextras={hasZextras} />

--- a/src/settings/auth-view.tsx
+++ b/src/settings/auth-view.tsx
@@ -63,7 +63,7 @@ function SideBar({
 	setActiveTab,
 	hasZextras
 }: {
-	activeTab: Tab;
+	activeTab: Tab | undefined;
 	setActiveTab: (activeTab: Tab) => void;
 	hasZextras: boolean;
 }): React.JSX.Element {

--- a/src/settings/auth-view.tsx
+++ b/src/settings/auth-view.tsx
@@ -21,18 +21,7 @@ import { ColumnFull, ColumnLeft, ColumnRight, Shell } from './components/shared/
 import { SidebarNavigation } from './components/shared/sidebar-navigation';
 import { checkSupportedZextras } from './network/checkSupportedZextras';
 import { fetchSoap } from './network/fetchSoap';
-import { Password } from './types';
-
-type Tab = {
-	name: string;
-	label: string;
-	view: (props?: {
-		passwords: Password[];
-		setPasswords: (passwords: Password[]) => void;
-	}) => React.JSX.Element;
-	instruction: string;
-	link?: string;
-};
+import { Password, Tab } from './types';
 
 function Instruction({
 	instruction,

--- a/src/settings/auth-view.tsx
+++ b/src/settings/auth-view.tsx
@@ -221,13 +221,7 @@ function ActiveTab({ activeTab }: { activeTab: Tab }): React.JSX.Element {
 		});
 	}, []);
 
-	return (
-		<activeTab.view
-			data-testid={`activeTab-${activeTab.name}`}
-			passwords={passwords}
-			setPasswords={setPasswords}
-		/>
-	);
+	return <activeTab.view passwords={passwords} setPasswords={setPasswords} />;
 }
 
 export default function App(): React.JSX.Element {

--- a/src/settings/auth-view.tsx
+++ b/src/settings/auth-view.tsx
@@ -21,11 +21,12 @@ import { ColumnFull, ColumnLeft, ColumnRight, Shell } from './components/shared/
 import { SidebarNavigation } from './components/shared/sidebar-navigation';
 import { checkSupportedZextras } from './network/checkSupportedZextras';
 import { fetchSoap } from './network/fetchSoap';
+import { Password } from './types';
 
 type Tab = {
 	name: string;
 	label: string;
-	view: (props: {
+	view: (props?: {
 		passwords: Password[];
 		setPasswords: (passwords: Password[]) => void;
 	}) => React.JSX.Element;
@@ -166,7 +167,6 @@ function SideBar({
 	]);
 
 	useEffect(() => {
-		/* eslint-disable react-hooks/exhaustive-deps */
 		setActiveTab(links[0]);
 	}, []);
 
@@ -198,10 +198,6 @@ function SideBar({
 		</Row>
 	);
 }
-
-type Password = {
-	created: number;
-};
 
 function ActiveTab({ activeTab }: { activeTab: Tab }): React.JSX.Element {
 	const [passwords, setPasswords] = useState<Password[]>([]);

--- a/src/settings/components/operations/app-desktop.tsx
+++ b/src/settings/components/operations/app-desktop.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable camelcase */
-/* disabled camelcase for NewPasswordProps */
 /*
  * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
  *
@@ -27,6 +24,8 @@ import { orderBy, isEmpty } from 'lodash';
 // @ts-ignore
 import { fetchSoap } from '../../network/fetchSoap';
 // @ts-ignore
+import { Password, TableRow, ViewProps } from '../../types';
+// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
 // @ts-ignore
 import { ErrorMessage } from '../shared/error-message';
@@ -41,27 +40,6 @@ const stepsNames = {
 	generate_password: 'generate_password',
 	delete_password: 'delete_password'
 };
-
-type PasswordProps = {
-	generated: number;
-	created: Date;
-	label: string;
-	id: string;
-	services: [
-		{
-			service: string;
-		}
-	];
-	hash: string;
-	enabled: boolean;
-	algorithm: string;
-};
-
-type AppDesktopProps = {
-	passwords: Array<PasswordProps>;
-	setPasswords: (arg: Array<PasswordProps>) => void;
-};
-
 type NewPasswordProps = {
 	qrcode_data: {
 		auth_method: string;
@@ -75,23 +53,10 @@ type NewPasswordProps = {
 			}
 		];
 	};
-	list: {
-		generated: string;
-		created: string;
-		label: string;
-		id: string;
-		services: [
-			{
-				service: string;
-			}
-		];
-		hash: string;
-		enabled: boolean;
-		algorithm: string;
-	};
+	list: [Password];
 };
 
-export function AppDesktop({ passwords, setPasswords }: AppDesktopProps): ReactElement {
+export function AppDesktop({ passwords, setPasswords }: ViewProps): ReactElement {
 	const [showModal, setShowModal] = useState(false);
 	const [step, setStep] = useState(stepsNames.set_label);
 	const [authDescription, setAuthDescription] = useState('');
@@ -123,16 +88,14 @@ export function AppDesktop({ passwords, setPasswords }: AppDesktopProps): ReactE
 
 	const tableRows = useMemo(
 		() =>
-			passwords.reduce((acc: any, p: any) => {
+			passwords.reduce((acc: TableRow[], p) => {
 				p.services[0].service === 'DesktopApp' &&
 					acc.push({
 						id: p.id,
 						columns: [
 							p.label,
 							p.enabled ? t('common.enabled', 'Enabled') : t('common.disabled', 'Disabled'),
-							p.services[0].service === 'EAS'
-								? t('easAuth.label', 'Exchange ActiveSync')
-								: t('appDesktop.label', 'Desktop Applications'),
+							t('appDesktop.label', 'Desktop Applications'),
 							formatDateUsingLocale(p.created)
 						],
 						clickable: true
@@ -142,7 +105,7 @@ export function AppDesktop({ passwords, setPasswords }: AppDesktopProps): ReactE
 		[passwords]
 	);
 
-	const updatePasswords = (): void =>
+	const updatePasswords = (): Promise<void> =>
 		fetchSoap('ListCredentialsRequest', {
 			_jsns: 'urn:zextrasClient'
 		}).then(
@@ -164,7 +127,7 @@ export function AppDesktop({ passwords, setPasswords }: AppDesktopProps): ReactE
 			}
 		);
 
-	const handleOnGenerateQrcode = (): void =>
+	const handleOnGenerateQrcode = (): Promise<void> =>
 		fetchSoap('AddCredentialRequest', {
 			_jsns: 'urn:zextrasClient',
 			label: authDescription,
@@ -181,7 +144,7 @@ export function AppDesktop({ passwords, setPasswords }: AppDesktopProps): ReactE
 			}
 		);
 
-	const handleOnDeletePassword = (): void =>
+	const handleOnDeletePassword = (): Promise<void> =>
 		fetchSoap('RemoveCredentialRequest', {
 			_jsns: 'urn:zextrasClient',
 			password_id: selectedPassword
@@ -252,7 +215,7 @@ export function AppDesktop({ passwords, setPasswords }: AppDesktopProps): ReactE
 
 	return (
 		<>
-			<Section title={t('appDesktop.title', 'Desktop Apps')} divider>
+			<Section title={t('appDesktop.title', 'Desktop Apps')}>
 				<Container>
 					<Row width="100%" mainAlignment="flex-end">
 						<Button

--- a/src/settings/components/operations/app-mobile.tsx
+++ b/src/settings/components/operations/app-mobile.tsx
@@ -26,6 +26,8 @@ import { QRCodeSVG } from 'qrcode.react';
 import { EmptyState } from '../../assets/icons/empty-state';
 import { fetchSoap } from '../../network/fetchSoap';
 // @ts-ignore
+import { ViewProps } from '../../types';
+// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
@@ -51,11 +53,6 @@ type PasswordProps = {
 	hash: string;
 	enabled: boolean;
 	algorithm: string;
-};
-
-type AppMobileProps = {
-	passwords: Array<PasswordProps>;
-	setPasswords: (arg: Array<PasswordProps>) => void;
 };
 
 type QrCodeProps = {
@@ -87,7 +84,7 @@ type QrCodeProps = {
 	};
 };
 
-export function AppMobile({ passwords, setPasswords }: AppMobileProps): ReactElement {
+export function AppMobile({ passwords, setPasswords }: ViewProps): ReactElement {
 	const [showModal, setShowModal] = useState(false);
 	const [step, setStep] = useState(stepsNames.set_label);
 	const [authDescription, setAuthDescription] = useState('');

--- a/src/settings/components/operations/app-mobile.tsx
+++ b/src/settings/components/operations/app-mobile.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
@@ -21,14 +22,15 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { isEmpty, orderBy } from 'lodash';
 import { QRCodeSVG } from 'qrcode.react';
 
+// @ts-ignore
 import { EmptyState } from '../../assets/icons/empty-state';
 import { fetchSoap } from '../../network/fetchSoap';
+// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
+// @ts-ignore
 import { copyToClipboard, formatDateUsingLocale } from '../utils';
-
-/* eslint-disable react/jsx-no-bind */
 
 const stepsNames = {
 	set_label: 'set_label',
@@ -242,7 +244,7 @@ export function AppMobile({ passwords, setPasswords }: AppMobileProps): ReactEle
 
 	return (
 		<>
-			<Section title={t('appMobile.title', 'Mobile Apps')} divider>
+			<Section title={t('appMobile.title', 'Mobile Apps')}>
 				<Container>
 					<Row width="100%" mainAlignment="flex-end">
 						<Button

--- a/src/settings/components/operations/app-mobile.tsx
+++ b/src/settings/components/operations/app-mobile.tsx
@@ -1,8 +1,5 @@
-/* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable camelcase */
 /*
- * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -24,17 +21,11 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { isEmpty, orderBy } from 'lodash';
 import { QRCodeSVG } from 'qrcode.react';
 
-// @ts-ignore
 import { EmptyState } from '../../assets/icons/empty-state';
-// @ts-ignore
 import { fetchSoap } from '../../network/fetchSoap';
-// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
-// @ts-ignore
 import { ErrorMessage } from '../shared/error-message';
-// @ts-ignore
 import { Section } from '../shared/section';
-// @ts-ignore
 import { copyToClipboard, formatDateUsingLocale } from '../utils';
 
 /* eslint-disable react/jsx-no-bind */
@@ -126,7 +117,6 @@ export function AppMobile({ passwords, setPasswords }: AppMobileProps): ReactEle
 	];
 
 	const tableRows = useMemo(
-		/* eslint-disable react-hooks/exhaustive-deps */
 		() =>
 			passwords.reduce((acc: any, p: any) => {
 				p.services[0].service === 'MobileApp' &&
@@ -147,7 +137,7 @@ export function AppMobile({ passwords, setPasswords }: AppMobileProps): ReactEle
 		[passwords]
 	);
 
-	const updatePasswords = (): void =>
+	const updatePasswords = (): Promise<void> =>
 		fetchSoap('ListCredentialsRequest', {
 			_jsns: 'urn:zextrasClient'
 		}).then(
@@ -169,7 +159,7 @@ export function AppMobile({ passwords, setPasswords }: AppMobileProps): ReactEle
 			}
 		);
 
-	const handleOnGenerateQrcode = (): void =>
+	const handleOnGenerateQrcode = (): Promise<void> =>
 		fetchSoap('AddCredentialRequest', {
 			_jsns: 'urn:zextrasClient',
 			label: authDescription,
@@ -181,7 +171,7 @@ export function AppMobile({ passwords, setPasswords }: AppMobileProps): ReactEle
 			}
 		});
 
-	const handleOnDeletePassword = (): void =>
+	const handleOnDeletePassword = (): Promise<void> =>
 		fetchSoap('RemoveCredentialRequest', {
 			_jsns: 'urn:zextrasClient',
 			password_id: selectedPassword

--- a/src/settings/components/operations/change-password.tsx
+++ b/src/settings/components/operations/change-password.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable no-console */
 /*
  * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
  *
@@ -138,7 +137,7 @@ export function ChangePassword(): React.JSX.Element {
 
 	return (
 		<>
-			<Section title={t('changePassword.title')} divider isDisabled>
+			<Section title={t('changePassword.title')}>
 				{isLocked && (
 					<Container
 						padding={{ vertical: 'medium', horizontal: 'small' }}
@@ -179,7 +178,7 @@ export function ChangePassword(): React.JSX.Element {
 							backgroundColor="gray5"
 							value={oldPassword}
 							onChange={(e): void => setOldPassword(e.target.value)}
-							hasError={errorLabelOldPassword}
+							hasError={!!errorLabelOldPassword}
 							disabled={isLocked}
 						/>
 						{errorLabelOldPassword && <ErrorMessage error={errorLabelOldPassword} />}
@@ -190,7 +189,7 @@ export function ChangePassword(): React.JSX.Element {
 							backgroundColor="gray5"
 							value={newPassword}
 							onChange={(e): void => setNewPassword(e.target.value)}
-							hasError={errorLabelNewPassword}
+							hasError={!!errorLabelNewPassword}
 							disabled={isLocked}
 						/>
 						{errorLabelNewPassword && <ErrorMessage error={errorLabelNewPassword} />}
@@ -201,7 +200,7 @@ export function ChangePassword(): React.JSX.Element {
 							backgroundColor="gray5"
 							value={confirmPassword}
 							onChange={(e): void => setConfirmPassword(e.target.value)}
-							hasError={errorLabelConfirmPassword}
+							hasError={!!errorLabelConfirmPassword}
 							disabled={isLocked}
 						/>
 						{errorLabelConfirmPassword && <ErrorMessage error={errorLabelConfirmPassword} />}
@@ -214,9 +213,9 @@ export function ChangePassword(): React.JSX.Element {
 							!oldPassword ||
 							!newPassword ||
 							!confirmPassword ||
-							errorLabelOldPassword ||
-							errorLabelNewPassword ||
-							errorLabelConfirmPassword ||
+							!!errorLabelOldPassword ||
+							!!errorLabelNewPassword ||
+							!!errorLabelConfirmPassword ||
 							isLocked
 						}
 						onClick={changePasswordSoap}

--- a/src/settings/components/operations/change-password.tsx
+++ b/src/settings/components/operations/change-password.tsx
@@ -24,7 +24,7 @@ import { fetchSoap } from '../../network/fetchSoap';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
 
-export function ChangePassword() {
+export function ChangePassword(): React.JSX.Element {
 	const [oldPassword, setOldPassword] = useState('');
 	const [newPassword, setNewPassword] = useState('');
 	const [confirmPassword, setConfirmPassword] = useState('');
@@ -32,7 +32,7 @@ export function ChangePassword() {
 	const [errorLabelNewPassword, setErrorLabelNewPassword] = useState('');
 	const [errorLabelConfirmPassword, setErrorLabelConfirmPassword] = useState('');
 	const [correctOldPassword, setCorrectOldPassword] = useState('');
-	const [isLocked, setIsLocked] = useState();
+	const [isLocked, setIsLocked] = useState<boolean>();
 	const settings = useUserSettings();
 
 	useEffect(() => {
@@ -42,7 +42,7 @@ export function ChangePassword() {
 
 	const createSnackbar = useSnackbar();
 
-	function formatPasswordRule(type, num) {
+	function formatPasswordRule(type: string, num: number): string {
 		switch (type) {
 			case 'zimbraPasswordMinLength':
 				return t('changePassword.zimbraPasswordMinLength', { num });
@@ -61,7 +61,7 @@ export function ChangePassword() {
 		}
 	}
 
-	function formatPasswordCode(code) {
+	function formatPasswordCode(code: string): void {
 		switch (code) {
 			case 'account.AUTH_FAILED':
 				setErrorLabelOldPassword(t('changePassword.incorrectPassword'));
@@ -71,28 +71,28 @@ export function ChangePassword() {
 				break;
 			default:
 				createSnackbar({
-					key: 2,
-					type: 'error',
+					key: '2',
+					severity: 'error',
 					label: t('error.somethingWrong'),
 					actionLabel: t('buttons.close')
 				});
 		}
 	}
 
-	const changePasswordSoap = () => {
+	const changePasswordSoap = (): void => {
 		fetchSoap('ChangePasswordRequest', {
 			_jsns: 'urn:zimbraAccount',
 			account: {
 				by: 'name',
-				_content: getUserAccount().name
+				_content: getUserAccount()?.name
 			},
 			oldPassword: { _content: oldPassword },
 			password: { _content: confirmPassword }
 		}).then((res) => {
 			if (res && 'ChangePasswordResponse' in res && 'authToken' in res.ChangePasswordResponse) {
 				createSnackbar({
-					key: 1,
-					type: 'success',
+					key: '1',
+					severity: 'success',
 					label: t('changePassword.passwordChanged'),
 					actionLabel: t('buttons.close')
 				});
@@ -106,8 +106,8 @@ export function ChangePassword() {
 				formatPasswordCode(code);
 			} else {
 				createSnackbar({
-					key: 2,
-					type: 'error',
+					key: '2',
+					severity: 'error',
 					label: t('error.somethingWrong'),
 					actionLabel: t('buttons.close')
 				});
@@ -178,7 +178,7 @@ export function ChangePassword() {
 							label={t('changePassword.oldPassword')}
 							backgroundColor="gray5"
 							value={oldPassword}
-							onChange={(e) => setOldPassword(e.target.value)}
+							onChange={(e): void => setOldPassword(e.target.value)}
 							hasError={errorLabelOldPassword}
 							disabled={isLocked}
 						/>
@@ -189,7 +189,7 @@ export function ChangePassword() {
 							label={t('newPassword')}
 							backgroundColor="gray5"
 							value={newPassword}
-							onChange={(e) => setNewPassword(e.target.value)}
+							onChange={(e): void => setNewPassword(e.target.value)}
 							hasError={errorLabelNewPassword}
 							disabled={isLocked}
 						/>
@@ -200,7 +200,7 @@ export function ChangePassword() {
 							label={t('changePassword.confirmNew')}
 							backgroundColor="gray5"
 							value={confirmPassword}
-							onChange={(e) => setConfirmPassword(e.target.value)}
+							onChange={(e): void => setConfirmPassword(e.target.value)}
 							hasError={errorLabelConfirmPassword}
 							disabled={isLocked}
 						/>

--- a/src/settings/components/operations/exchange-active-sync.tsx
+++ b/src/settings/components/operations/exchange-active-sync.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 /*
  * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
  *
@@ -22,15 +24,18 @@ import { t } from '@zextras/carbonio-shell-ui';
 import { isEmpty, orderBy } from 'lodash';
 import styled from 'styled-components';
 
+// @ts-ignore
 import { EmptyState } from '../../assets/icons/empty-state';
+// @ts-ignore
 import { PoweredByZextras } from '../../assets/icons/powered-by-zextras';
 import { fetchSoap } from '../../network/fetchSoap';
+import { PasswordId, TableRow, ViewProps } from '../../types';
+// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
+// @ts-ignore
 import { copyToClipboard, formatDateUsingLocale } from '../utils';
-
-/* eslint-disable react/jsx-no-bind */
 
 const stepsNames = {
 	set_label: 'set_label',
@@ -44,10 +49,12 @@ const TextPasswordContainer = styled(Row)`
 	background-color: ${({ theme }: { theme: Theme }): string => theme.palette.gray5.regular};
 `;
 
-export function ExchangeActiveSync({ passwords, setPasswords }): React.JSX.Element {
+export function ExchangeActiveSync({ passwords, setPasswords }: ViewProps): React.JSX.Element {
 	const [authDescription, setAuthDescription] = useState('');
-	const [newPasswordResponse, setNewPasswordResponse] = useState();
-	const [selectedPassword, setSelectedPassword] = useState();
+	const [newPasswordResponse, setNewPasswordResponse] = useState<{
+		text_data: { password: string };
+	}>();
+	const [selectedPassword, setSelectedPassword] = useState<PasswordId>();
 	const [showModal, setShowModal] = useState(false);
 	const [step, setStep] = useState(stepsNames.set_label);
 	const createSnackbar = useSnackbar();
@@ -77,7 +84,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }): React.JSX.Eleme
 
 	const tableRows = useMemo(
 		() =>
-			passwords.reduce((acc, p) => {
+			passwords.reduce((acc: TableRow[], p) => {
 				p.services[0].service === 'EAS' &&
 					acc.push({
 						id: p.id,
@@ -149,7 +156,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }): React.JSX.Eleme
 		return '';
 	}, [authDescription]);
 
-	function ActionButton(): React.JSX.Element | undefined {
+	function ActionButton(): React.JSX.Element {
 		if (step === stepsNames.set_label) {
 			return (
 				<Button
@@ -184,11 +191,12 @@ export function ExchangeActiveSync({ passwords, setPasswords }): React.JSX.Eleme
 				/>
 			);
 		}
+		return <></>;
 	}
 
 	return (
 		<>
-			<Section title={t('easAuth.label')} divider>
+			<Section title={t('easAuth.label')}>
 				<Container>
 					<Row width="100%" mainAlignment="flex-end">
 						<Button

--- a/src/settings/components/operations/exchange-active-sync.tsx
+++ b/src/settings/components/operations/exchange-active-sync.tsx
@@ -15,6 +15,7 @@ import {
 	Row,
 	Table,
 	Text,
+	Theme,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
@@ -40,10 +41,10 @@ const stepsNames = {
 const TextPasswordContainer = styled(Row)`
 	font-family: monospace;
 	font-size: 1.25rem;
-	background-color: ${({ theme }) => theme.palette.gray5.regular};
+	background-color: ${({ theme }: { theme: Theme }): string => theme.palette.gray5.regular};
 `;
 
-export function ExchangeActiveSync({ passwords, setPasswords }) {
+export function ExchangeActiveSync({ passwords, setPasswords }): React.JSX.Element {
 	const [authDescription, setAuthDescription] = useState('');
 	const [newPasswordResponse, setNewPasswordResponse] = useState();
 	const [selectedPassword, setSelectedPassword] = useState();
@@ -75,7 +76,6 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 	];
 
 	const tableRows = useMemo(
-		/* eslint-disable react-hooks/exhaustive-deps */
 		() =>
 			passwords.reduce((acc, p) => {
 				p.services[0].service === 'EAS' &&
@@ -94,7 +94,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 		[passwords]
 	);
 
-	const updatePasswords = () =>
+	const updatePasswords = (): Promise<void> =>
 		fetchSoap('ListCredentialsRequest', {
 			// eslint-disable-next-line sonarjs/no-duplicate-string
 			_jsns: 'urn:zextrasClient'
@@ -109,7 +109,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 				);
 		});
 
-	const handleOnGeneratePassword = () =>
+	const handleOnGeneratePassword = (): Promise<void> =>
 		fetchSoap('AddCredentialRequest', {
 			_jsns: 'urn:zextrasClient',
 			label: authDescription,
@@ -121,7 +121,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 			}
 		});
 
-	const handleOnDeletePassword = () =>
+	const handleOnDeletePassword = (): Promise<void> =>
 		fetchSoap('RemoveCredentialRequest', {
 			_jsns: 'urn:zextrasClient',
 			password_id: selectedPassword
@@ -129,14 +129,14 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 			res.response.ok && updatePasswords();
 		});
 
-	const handleOnClose = (showSnackbar = false) => {
+	const handleOnClose = (showSnackbar = false): void => {
 		setShowModal(false);
 		setAuthDescription('');
 		setStep(stepsNames.set_label);
 		showSnackbar &&
 			createSnackbar({
-				key: 1,
-				type: 'success',
+				key: '1',
+				severity: 'success',
 				label: t('easAuth.success')
 			});
 	};
@@ -149,13 +149,13 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 		return '';
 	}, [authDescription]);
 
-	function ActionButton() {
+	function ActionButton(): React.JSX.Element | undefined {
 		if (step === stepsNames.set_label) {
 			return (
 				<Button
 					label={t('common.createPassword')}
 					disabled={authDescription === ''}
-					onClick={() => {
+					onClick={(): void => {
 						setStep(stepsNames.generate_password);
 						handleOnGeneratePassword();
 					}}
@@ -166,7 +166,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 			return (
 				<Button
 					label={t('buttons.done')}
-					onClick={() => {
+					onClick={(): void => {
 						handleOnClose(true);
 					}}
 				/>
@@ -177,7 +177,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 				<Button
 					label={t('buttons.yes')}
 					color="error"
-					onClick={() => {
+					onClick={(): void => {
 						handleOnDeletePassword();
 						handleOnClose();
 					}}
@@ -197,7 +197,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 							color="error"
 							icon="CloseOutline"
 							disabled={!selectedPassword || tableRows.length === 0}
-							onClick={() => {
+							onClick={(): void => {
 								setShowModal(true);
 								setStep(stepsNames.delete_password);
 							}}
@@ -207,7 +207,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 								label={t('common.newAuthentication')}
 								type="outlined"
 								icon="Plus"
-								onClick={() => setShowModal(true)}
+								onClick={(): void => setShowModal(true)}
 							/>
 						</Padding>
 					</Row>
@@ -218,7 +218,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 								headers={tableHeaders}
 								showCheckbox={false}
 								multiSelect={false}
-								onSelectionChange={(selected) => setSelectedPassword(selected[0])}
+								onSelectionChange={(selected): void => setSelectedPassword(selected[0])}
 							/>
 							{isEmpty(tableRows) && (
 								<Container padding="4rem 0 0">
@@ -235,7 +235,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 			<Modal
 				title={t('easAuth.new')}
 				open={showModal}
-				onClose={() => handleOnClose(false)}
+				onClose={(): void => handleOnClose(false)}
 				customFooter={
 					<Row width="100%" mainAlignment="space-between" crossAlignment="flex-end">
 						<PoweredByZextras />
@@ -244,7 +244,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 								label={
 									step === stepsNames.delete_password ? t('buttons.cancel') : t('buttons.close')
 								}
-								onClick={() => handleOnClose()}
+								onClick={(): void => handleOnClose()}
 								color="secondary"
 							/>
 							<Padding left="small">
@@ -260,7 +260,7 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 							<Input
 								label={t('setNewPassword.authenticationDescription')}
 								value={authDescription}
-								onChange={(e) => setAuthDescription(e.target.value)}
+								onChange={(e): void => setAuthDescription(e.target.value)}
 								backgroundColor="gray5"
 							/>
 							{formatError && <ErrorMessage error={formatError} />}
@@ -293,13 +293,13 @@ export function ExchangeActiveSync({ passwords, setPasswords }) {
 									<Button
 										label={t('common.copyPassword')}
 										type="outlined"
-										onClick={() => {
+										onClick={(): void => {
 											copyToClipboard(
 												newPasswordResponse && newPasswordResponse.text_data.password
 											);
 											createSnackbar({
-												key: 1,
-												type: 'info',
+												key: '1',
+												severity: 'info',
 												label: t('setNewPassword.EASPasswordCopied')
 											});
 										}}

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 /*
  * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
@@ -23,7 +25,9 @@ import { isEmpty, map, orderBy, reduce } from 'lodash';
 import QRCode from 'qrcode.react';
 import styled, { useTheme } from 'styled-components';
 
+// @ts-ignore
 import { EmptyState } from '../../assets/icons/empty-state';
+// @ts-ignore
 import { PoweredByZextras } from '../../assets/icons/powered-by-zextras';
 import {
 	otpCodesLoginPage,
@@ -31,11 +35,14 @@ import {
 	otpCodesTypePin,
 	poweredByZextras,
 	zextrasLogo
+	// @ts-ignore
 } from '../../assets/icons/svgAssets';
 import { fetchSoap } from '../../network/fetchSoap';
+// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
+// @ts-ignore
 import { copyToClipboard, formatDateUsingLocale } from '../utils';
 
 /* eslint-disable react/jsx-no-bind */
@@ -78,7 +85,7 @@ export function OTPAuthentication(): React.JSX.Element {
 	const [errorLabel, setErrorLabel] = useState('');
 	const [pinCodes, setPinCodes] = useState([]);
 
-	const userMail = useRef();
+	const userMail = useRef<string>();
 
 	const createSnackbar = useSnackbar();
 
@@ -451,7 +458,7 @@ export function OTPAuthentication(): React.JSX.Element {
 
 	return (
 		<>
-			<Section title={t('setNewOtpLabel.title')} divider>
+			<Section title={t('setNewOtpLabel.title')}>
 				<Container>
 					<Row width="100%" mainAlignment="flex-end">
 						<Button

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -39,7 +39,7 @@ import {
 } from '../../assets/icons/svgAssets';
 import { fetchSoap } from '../../network/fetchSoap';
 // @ts-ignore
-import { Otp, OtpTableRow } from '../../types';
+import { Otp, OtpId, OtpTableRow } from '../../types';
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
@@ -74,17 +74,30 @@ const QRCodeRow = styled(Row)`
 	border-radius: ${({ theme }: { theme: Theme }): string => theme.borderRadius};
 `;
 
+type PinCode = { code: string };
+
+type LabelsObj = {
+	title: string;
+	typePin: string;
+	login: string;
+	eraseUsedPin: boolean;
+	howToUse: string;
+	whenToUse: string;
+	useOnce: string;
+	keepInSafePlace: string;
+};
+
 export function OTPAuthentication(): React.JSX.Element {
 	const theme = useTheme();
 
 	const [otpList, setOTPList] = useState<Otp[]>([]);
-	const [selectedOTP, setSelectedOTP] = useState();
+	const [selectedOTP, setSelectedOTP] = useState<OtpId>();
 	const [showModal, setShowModal] = useState(false);
 	const [modalStep, setModalStep] = useState(stepsNames.set_label);
 	const [otpLabel, setOTPLabel] = useState('');
 	const [qrData, setQrData] = useState();
 	const [errorLabel, setErrorLabel] = useState('');
-	const [pinCodes, setPinCodes] = useState([]);
+	const [pinCodes, setPinCodes] = useState<Record<string>>([]);
 
 	const userMail = useRef<string>();
 
@@ -200,7 +213,7 @@ export function OTPAuthentication(): React.JSX.Element {
 			return (
 				<Button
 					label={t('common.createPassword')}
-					disabled={otpLabel === '' || errorLabel}
+					disabled={otpLabel === '' || !!errorLabel}
 					onClick={(): void => {
 						handleOnGenerateOTP();
 					}}
@@ -242,7 +255,7 @@ export function OTPAuthentication(): React.JSX.Element {
 		}
 	}
 
-	function printCodes(codes, labelsObj): void {
+	function printCodes(codes: Record<string, PinCode>, labelsObj: LabelsObj): void {
 		const iframe = document.createElement('iframe');
 		document.body.appendChild(iframe);
 
@@ -488,7 +501,7 @@ export function OTPAuthentication(): React.JSX.Element {
 							headers={tableHeaders}
 							showCheckbox={false}
 							multiSelect={false}
-							onSelectionChange={(selected) => setSelectedOTP(selected[0])}
+							onSelectionChange={(selected): void => setSelectedOTP(selected[0])}
 						/>
 						{isEmpty(tableRows) && (
 							<Container padding="4rem 0 0">
@@ -533,7 +546,7 @@ export function OTPAuthentication(): React.JSX.Element {
 								value={otpLabel}
 								onChange={(e): void => setOTPLabel(e.target.value)}
 								backgroundColor="gray5"
-								hasError={errorLabel}
+								hasError={!!errorLabel}
 							/>
 							{errorLabel && <ErrorMessage error={errorLabel} />}
 							<Padding vertical="medium" style={{ textAlign: 'center' }} />

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../assets/icons/svgAssets';
 import { fetchSoap } from '../../network/fetchSoap';
 // @ts-ignore
+import { Otp, OtpTableRow } from '../../types';
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
@@ -76,7 +77,7 @@ const QRCodeRow = styled(Row)`
 export function OTPAuthentication(): React.JSX.Element {
 	const theme = useTheme();
 
-	const [otpList, setOTPList] = useState([]);
+	const [otpList, setOTPList] = useState<Otp[]>([]);
 	const [selectedOTP, setSelectedOTP] = useState();
 	const [showModal, setShowModal] = useState(false);
 	const [modalStep, setModalStep] = useState(stepsNames.set_label);
@@ -116,7 +117,7 @@ export function OTPAuthentication(): React.JSX.Element {
 	const tableRows = useMemo(
 		/* eslint-disable no-nested-ternary, react-hooks/exhaustive-deps */
 		() =>
-			otpList.reduce((acc, otp) => {
+			otpList.reduce((acc: OtpTableRow[], otp) => {
 				acc.push({
 					id: otp.id,
 					columns: [

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -23,7 +23,7 @@ import {
 } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 import { isEmpty, map, orderBy, reduce } from 'lodash';
-import QRCode, { QRCodeSVG } from 'qrcode.react';
+import { QRCodeSVG } from 'qrcode.react';
 import styled, { useTheme } from 'styled-components';
 
 // @ts-ignore

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -23,7 +23,7 @@ import {
 } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
 import { isEmpty, map, orderBy, reduce } from 'lodash';
-import QRCode from 'qrcode.react';
+import QRCode, { QRCodeSVG } from 'qrcode.react';
 import styled, { useTheme } from 'styled-components';
 
 // @ts-ignore
@@ -82,7 +82,7 @@ type LabelsObj = {
 	title: string;
 	typePin: string;
 	login: string;
-	eraseUsedPin: boolean;
+	eraseUsedPin: string;
 	howToUse: string;
 	whenToUse: string;
 	useOnce: string;
@@ -90,7 +90,7 @@ type LabelsObj = {
 };
 
 export function OTPAuthentication(): React.JSX.Element {
-	const theme = useTheme();
+	const theme = useTheme() as Theme;
 
 	const [otpList, setOTPList] = useState<Otp[]>([]);
 	const [selectedOTP, setSelectedOTP] = useState<OtpId>();
@@ -99,7 +99,7 @@ export function OTPAuthentication(): React.JSX.Element {
 	const [otpLabel, setOTPLabel] = useState('');
 	const [qrData, setQrData] = useState();
 	const [errorLabel, setErrorLabel] = useState('');
-	const [pinCodes, setPinCodes] = useState<Record<string, PinCode>>([]);
+	const [pinCodes, setPinCodes] = useState<Record<string, PinCode>>({});
 
 	const userMail = useRef<string>();
 
@@ -210,7 +210,7 @@ export function OTPAuthentication(): React.JSX.Element {
 			});
 	};
 
-	function ActionButton(): React.JSX.Element | undefined {
+	function ActionButton(): React.JSX.Element {
 		if (modalStep === stepsNames.set_label) {
 			return (
 				<Button
@@ -255,6 +255,7 @@ export function OTPAuthentication(): React.JSX.Element {
 				/>
 			);
 		}
+		return <></>;
 	}
 
 	function printCodes(codes: Record<string, PinCode>, labelsObj: LabelsObj): void {
@@ -568,7 +569,7 @@ export function OTPAuthentication(): React.JSX.Element {
 									orientation="vertical"
 									padding={{ all: 'large' }}
 								>
-									<QRCode
+									<QRCodeSVG
 										includeMargin
 										data-testid="qrcode-password"
 										size={150}

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -15,6 +15,7 @@ import {
 	Row,
 	Table,
 	Text,
+	Theme,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
 import { t } from '@zextras/carbonio-shell-ui';
@@ -62,10 +63,10 @@ const StaticCode = styled.label`
 `;
 
 const QRCodeRow = styled(Row)`
-	border-radius: ${({ theme }) => theme.borderRadius};
+	border-radius: ${({ theme }: { theme: Theme }): string => theme.borderRadius};
 `;
 
-export function OTPAuthentication() {
+export function OTPAuthentication(): React.JSX.Element {
 	const theme = useTheme();
 
 	const [otpList, setOTPList] = useState([]);
@@ -139,7 +140,7 @@ export function OTPAuthentication() {
 		[otpList]
 	);
 
-	const handleOnGenerateOTP = () =>
+	const handleOnGenerateOTP = (): Promise<void> =>
 		fetchSoap('GenerateOTPRequest', {
 			// eslint-disable-next-line sonarjs/no-duplicate-string
 			_jsns: 'urn:zextrasClient',
@@ -159,14 +160,14 @@ export function OTPAuthentication() {
 			}
 		});
 
-	const updateOTPList = () =>
+	const updateOTPList = (): Promise<void> =>
 		fetchSoap('ListOTPRequest', {
 			_jsns: 'urn:zextrasClient'
 		}).then((res) => {
 			res.response.ok && setOTPList(orderBy(res.response.value.list, ['created'], ['desc']));
 		});
 
-	const handleOnDeleteOTP = () =>
+	const handleOnDeleteOTP = (): Promise<void> =>
 		fetchSoap('DeleteOTPRequest', {
 			_jsns: 'urn:zextrasClient',
 			id: selectedOTP
@@ -174,25 +175,25 @@ export function OTPAuthentication() {
 			res.response.ok && updateOTPList();
 		});
 
-	const handleOnClose = (showSnackbar = false) => {
+	const handleOnClose = (showSnackbar = false): void => {
 		setShowModal(false);
 		setModalStep(stepsNames.set_label);
 		setOTPLabel('');
 		showSnackbar &&
 			createSnackbar({
-				key: 1,
-				type: 'success',
+				key: '1',
+				severity: 'success',
 				label: t('setNewOtpLabel.success')
 			});
 	};
 
-	function ActionButton() {
+	function ActionButton(): React.JSX.Element | undefined {
 		if (modalStep === stepsNames.set_label) {
 			return (
 				<Button
 					label={t('common.createPassword')}
 					disabled={otpLabel === '' || errorLabel}
-					onClick={() => {
+					onClick={(): void => {
 						handleOnGenerateOTP();
 					}}
 				/>
@@ -202,7 +203,7 @@ export function OTPAuthentication() {
 			return (
 				<Button
 					label={t('buttons.next')}
-					onClick={() => {
+					onClick={(): void => {
 						setModalStep(stepsNames.show_pin_codes);
 					}}
 				/>
@@ -213,7 +214,7 @@ export function OTPAuthentication() {
 				<Button
 					label={t('buttons.yes')}
 					color="error"
-					onClick={() => {
+					onClick={(): void => {
 						handleOnDeleteOTP();
 						handleOnClose();
 					}}
@@ -224,7 +225,7 @@ export function OTPAuthentication() {
 			return (
 				<Button
 					label={t('buttons.done')}
-					onClick={() => {
+					onClick={(): void => {
 						handleOnClose(true);
 						updateOTPList();
 					}}
@@ -233,7 +234,7 @@ export function OTPAuthentication() {
 		}
 	}
 
-	function printCodes(codes, labelsObj) {
+	function printCodes(codes, labelsObj): void {
 		const iframe = document.createElement('iframe');
 		document.body.appendChild(iframe);
 
@@ -425,11 +426,11 @@ export function OTPAuthentication() {
 			</html>
 		`;
 
-		iframe.contentWindow.document.open('text/html', 'replace');
-		iframe.contentWindow.document.write(htmlCode);
-		iframe.contentWindow.document.close();
+		iframe?.contentWindow?.document.open('text/html', 'replace');
+		iframe?.contentWindow?.document.write(htmlCode);
+		iframe?.contentWindow?.document.close();
 
-		iframe.contentWindow.print();
+		iframe?.contentWindow?.print();
 		setTimeout(() => iframe.remove(), 100);
 	}
 
@@ -459,7 +460,7 @@ export function OTPAuthentication() {
 							color="error"
 							icon="CloseOutline"
 							disabled={!selectedOTP || tableRows.length === 0}
-							onClick={() => {
+							onClick={(): void => {
 								setShowModal(true);
 								setModalStep(stepsNames.delete_password);
 							}}
@@ -469,7 +470,7 @@ export function OTPAuthentication() {
 								label={t('newOtp.label')}
 								type="outlined"
 								icon="Plus"
-								onClick={() => setShowModal(true)}
+								onClick={(): void => setShowModal(true)}
 							/>
 						</Padding>
 					</Row>
@@ -495,7 +496,7 @@ export function OTPAuthentication() {
 			<Modal
 				title={t('setNewOtpLabel.new')}
 				open={showModal}
-				onClose={() => handleOnClose(false)}
+				onClose={(): void => handleOnClose(false)}
 				customFooter={
 					<Row width="100%" mainAlignment="space-between" crossAlignment="flex-end">
 						<PoweredByZextras />
@@ -506,7 +507,7 @@ export function OTPAuthentication() {
 										? t('buttons.cancel')
 										: t('buttons.close')
 								}
-								onClick={() => handleOnClose()}
+								onClick={(): void => handleOnClose()}
 								color="secondary"
 							/>
 							<Padding left="small">
@@ -522,7 +523,7 @@ export function OTPAuthentication() {
 							<Input
 								label={t('setNewOtpLabel.inputLabel')}
 								value={otpLabel}
-								onChange={(e) => setOTPLabel(e.target.value)}
+								onChange={(e): void => setOTPLabel(e.target.value)}
 								backgroundColor="gray5"
 								hasError={errorLabel}
 							/>
@@ -555,10 +556,10 @@ export function OTPAuthentication() {
 										<Button
 											label={t('common.copyQrCode')}
 											type="outlined"
-											onClick={() => {
+											onClick={(): void => {
 												copyToClipboard(qrData);
 												createSnackbar({
-													key: 2,
+													key: '2',
 													label: t('common.codeCopied')
 												});
 											}}
@@ -585,7 +586,7 @@ export function OTPAuthentication() {
 											<Button
 												type="outlined"
 												label={t('newOtp.printPinCodes')}
-												onClick={() =>
+												onClick={(): void =>
 													printCodes(pinCodes, {
 														title: t('staticOTPCodes.print.title'),
 														whenToUse: t('staticOTPCodes.print.whenToUse'),

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -17,6 +17,7 @@ import {
 	Row,
 	Table,
 	Text,
+	THeader,
 	Theme,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
@@ -40,6 +41,7 @@ import {
 import { fetchSoap } from '../../network/fetchSoap';
 // @ts-ignore
 import { Otp, OtpId, OtpTableRow } from '../../types';
+// @ts-ignore
 import { BigIcon } from '../shared/big-icon';
 import { ErrorMessage } from '../shared/error-message';
 import { Section } from '../shared/section';
@@ -97,13 +99,13 @@ export function OTPAuthentication(): React.JSX.Element {
 	const [otpLabel, setOTPLabel] = useState('');
 	const [qrData, setQrData] = useState();
 	const [errorLabel, setErrorLabel] = useState('');
-	const [pinCodes, setPinCodes] = useState<Record<string>>([]);
+	const [pinCodes, setPinCodes] = useState<Record<string, PinCode>>([]);
 
 	const userMail = useRef<string>();
 
 	const createSnackbar = useSnackbar();
 
-	const tableHeaders = [
+	const tableHeaders: THeader[] = [
 		{
 			id: 'code',
 			label: t('passwordListLabel.label', 'Description'),

--- a/src/settings/components/operations/otp-authentication.tsx
+++ b/src/settings/components/operations/otp-authentication.tsx
@@ -99,7 +99,7 @@ export function OTPAuthentication(): React.JSX.Element {
 	const [otpLabel, setOTPLabel] = useState('');
 	const [qrData, setQrData] = useState();
 	const [errorLabel, setErrorLabel] = useState('');
-	const [pinCodes, setPinCodes] = useState<Record<string, PinCode>>({});
+	const [pinCodes, setPinCodes] = useState<PinCode[]>([]);
 
 	const userMail = useRef<string>();
 
@@ -258,7 +258,7 @@ export function OTPAuthentication(): React.JSX.Element {
 		return <></>;
 	}
 
-	function printCodes(codes: Record<string, PinCode>, labelsObj: LabelsObj): void {
+	function printCodes(codes: PinCode[], labelsObj: LabelsObj): void {
 		const iframe = document.createElement('iframe');
 		document.body.appendChild(iframe);
 

--- a/src/settings/components/operations/recovery-password.tsx
+++ b/src/settings/components/operations/recovery-password.tsx
@@ -20,8 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { isValidEmail } from '../../../utils/email';
 import { useGenericErrorSnackbar } from '../../hooks/use-generic-error-snackbar';
 import { setRecoveryAccountRequest } from '../../network/set-recovery-account-request';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 import { Section } from '../shared/section';
 
 export const RecoveryPassword = (): JSX.Element => {
@@ -51,11 +49,11 @@ export const RecoveryPassword = (): JSX.Element => {
 		[recoveryAddressStatus]
 	);
 
-	const onAddressInputChange = useCallback((e) => {
+	const onAddressInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
 		setPasswordRecoveryAddress(e.target.value);
 	}, []);
 
-	const onCodeInputChange = useCallback((e) => {
+	const onCodeInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
 		setCodeValue(e.target.value);
 	}, []);
 

--- a/src/settings/components/operations/recovery-password.tsx
+++ b/src/settings/components/operations/recovery-password.tsx
@@ -158,7 +158,7 @@ export const RecoveryPassword = (): JSX.Element => {
 	);
 
 	return (
-		<Section title={t('recoveryAddress.title', 'Recovery Address')} divider>
+		<Section title={t('recoveryAddress.title', 'Recovery Address')}>
 			{isRecoveryAddressStatusVerified ? (
 				<>
 					<Padding top="large" />

--- a/src/settings/components/operations/reset-password.tsx
+++ b/src/settings/components/operations/reset-password.tsx
@@ -13,7 +13,7 @@ import {
 	Text,
 	useSnackbar
 } from '@zextras/carbonio-design-system';
-import { useTranslation } from 'react-i18next';
+import { t } from '@zextras/carbonio-shell-ui';
 
 import { useGenericErrorSnackbar } from '../../hooks/use-generic-error-snackbar';
 import { resetPasswordRequest } from '../../network/reset-password-request';
@@ -22,7 +22,6 @@ import { resetPasswordRequest } from '../../network/reset-password-request';
 import { Section } from '../shared/section';
 
 export function ResetPassword(): JSX.Element {
-	const [t] = useTranslation();
 	const createSnackbar = useSnackbar();
 	const errorSnackbar = useGenericErrorSnackbar();
 

--- a/src/settings/components/operations/reset-password.tsx
+++ b/src/settings/components/operations/reset-password.tsx
@@ -60,7 +60,7 @@ export function ResetPassword(): JSX.Element {
 	);
 
 	return (
-		<Section title={t('settingsAuth.Displayer.ResetPassword', 'Reset Password')} divider isDisabled>
+		<Section title={t('settingsAuth.Displayer.ResetPassword', 'Reset Password')}>
 			<Row mainAlignment="flex-start" width="fill">
 				<Padding bottom="large">
 					<Text overflow="break-word">

--- a/src/settings/components/operations/reset-password.tsx
+++ b/src/settings/components/operations/reset-password.tsx
@@ -52,7 +52,7 @@ export function ResetPassword(): JSX.Element {
 				errorSnackbar(res?.Fault?.Reason?.Text);
 			}
 		});
-	}, [createSnackbar, errorSnackbar, newPasswordValue, resetValues, t]);
+	}, [createSnackbar, errorSnackbar, newPasswordValue, resetValues]);
 
 	const hasMatchError = useMemo(
 		() => confirmPasswordValue.length > 0 && newPasswordValue !== confirmPasswordValue,

--- a/src/settings/components/shared/error-message.tsx
+++ b/src/settings/components/shared/error-message.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import { Row, Text } from '@zextras/carbonio-design-system';
 
-export function ErrorMessage({ error }) {
+export function ErrorMessage({ error }: { error: string }): React.JSX.Element {
 	return (
 		<Row width="fill" mainAlignment="flex-start" padding={{ top: 'extrasmall' }}>
 			<Text size="small" color="error">

--- a/src/settings/components/shared/section.tsx
+++ b/src/settings/components/shared/section.tsx
@@ -6,29 +6,9 @@
 
 import React from 'react';
 
-import { Button, Container, Divider, Padding, Text, Row } from '@zextras/carbonio-design-system';
+import { Container, Divider, Text, Row } from '@zextras/carbonio-design-system';
 
-type SectionHeaderProps = {
-	title: string;
-	divider: boolean;
-	showButtons: boolean;
-	saveLabel: string;
-	onSave: () => void;
-	onCancel: () => void;
-	isSaving: boolean;
-	isDisabled: boolean;
-};
-
-function SectionHeader({
-	title,
-	divider,
-	showButtons,
-	saveLabel,
-	onSave,
-	onCancel,
-	isSaving,
-	isDisabled
-}: SectionHeaderProps): React.JSX.Element {
+function SectionHeader({ title }: { title: string }): React.JSX.Element {
 	return (
 		<Container width="100%" height="fit">
 			<Row mainAlignment="flex-start" crossAlignment="center" width="100%" height="auto">
@@ -37,26 +17,8 @@ function SectionHeader({
 						{title}
 					</Text>
 				</Row>
-				{showButtons && (
-					<Row padding={{ horizontal: 'small' }}>
-						<Padding right="small">
-							<Button
-								label={'cancel'}
-								color="secondary"
-								onClick={onCancel}
-								disabled={isSaving || isDisabled}
-							/>
-						</Padding>
-						<Button
-							label={saveLabel || 'save'}
-							onClick={onSave}
-							loading={isSaving}
-							disabled={isSaving || isDisabled}
-						/>
-					</Row>
-				)}
 			</Row>
-			{divider && <Divider />}
+			<Divider />
 		</Container>
 	);
 }
@@ -80,16 +42,10 @@ function SectionBody({
 	);
 }
 
-function SectionFooter({
-	divider,
-	footer
-}: {
-	divider: boolean;
-	footer: React.JSX.Element;
-}): React.JSX.Element {
+function SectionFooter({ footer }: { footer: React.JSX.Element }): React.JSX.Element {
 	return (
 		<Container width="100%" height="fit">
-			{divider && <Divider />}
+			<Divider />
 			<Container height="fit" padding={{ all: 'large' }}>
 				{footer}
 			</Container>
@@ -98,46 +54,23 @@ function SectionFooter({
 }
 
 type SectionProps = {
-	children: React.ReactNode;
+	children?: React.ReactNode;
 	title: string;
-	divider: boolean;
-	footer: React.JSX.Element;
-	showButtons: boolean;
-	saveLabel: string;
-	onSave: () => void;
-	onCancel: () => void;
-	isSaving: boolean;
-	padding: { all: string };
-	isDisabled: boolean;
+	footer?: React.JSX.Element;
+	padding?: { all: string };
 };
 
 export function Section({
 	children,
 	title,
-	divider,
 	footer,
-	showButtons,
-	saveLabel,
-	onSave,
-	onCancel,
-	isSaving,
-	padding = { all: 'large' },
-	isDisabled
+	padding = { all: 'large' }
 }: SectionProps): React.JSX.Element {
 	return (
 		<Container background="gray6" height="fill" mainAlignment="flex-start">
-			<SectionHeader
-				title={title}
-				showButtons={showButtons}
-				saveLabel={saveLabel}
-				onSave={onSave}
-				onCancel={onCancel}
-				isSaving={isSaving}
-				isDisabled={isDisabled}
-				divider={divider}
-			/>
+			<SectionHeader title={title} />
 			<SectionBody padding={padding}>{children}</SectionBody>
-			{footer && <SectionFooter divider={divider} footer={footer} />}
+			{footer && <SectionFooter footer={footer} />}
 		</Container>
 	);
 }

--- a/src/settings/components/shared/section.tsx
+++ b/src/settings/components/shared/section.tsx
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -7,6 +7,17 @@
 import React from 'react';
 
 import { Button, Container, Divider, Padding, Text, Row } from '@zextras/carbonio-design-system';
+
+type SectionHeaderProps = {
+	title: string;
+	divider: boolean;
+	showButtons: boolean;
+	saveLabel: string;
+	onSave: () => void;
+	onCancel: () => void;
+	isSaving: boolean;
+	isDisabled: boolean;
+};
 
 function SectionHeader({
 	title,
@@ -17,7 +28,7 @@ function SectionHeader({
 	onCancel,
 	isSaving,
 	isDisabled
-}) {
+}: SectionHeaderProps): React.JSX.Element {
 	return (
 		<Container width="100%" height="fit">
 			<Row mainAlignment="flex-start" crossAlignment="center" width="100%" height="auto">
@@ -50,7 +61,13 @@ function SectionHeader({
 	);
 }
 
-function SectionBody({ padding, children }) {
+function SectionBody({
+	padding,
+	children
+}: {
+	padding: { all: string };
+	children: React.ReactNode;
+}): React.JSX.Element {
 	return (
 		<Container
 			mainAlignment="flex-start"
@@ -63,7 +80,13 @@ function SectionBody({ padding, children }) {
 	);
 }
 
-function SectionFooter({ divider, footer }) {
+function SectionFooter({
+	divider,
+	footer
+}: {
+	divider: boolean;
+	footer: React.JSX.Element;
+}): React.JSX.Element {
 	return (
 		<Container width="100%" height="fit">
 			{divider && <Divider />}
@@ -73,6 +96,20 @@ function SectionFooter({ divider, footer }) {
 		</Container>
 	);
 }
+
+type SectionProps = {
+	children: React.ReactNode;
+	title: string;
+	divider: boolean;
+	footer: React.JSX.Element;
+	showButtons: boolean;
+	saveLabel: string;
+	onSave: () => void;
+	onCancel: () => void;
+	isSaving: boolean;
+	padding: { all: string };
+	isDisabled: boolean;
+};
 
 export function Section({
 	children,
@@ -86,7 +123,7 @@ export function Section({
 	isSaving,
 	padding = { all: 'large' },
 	isDisabled
-}) {
+}: SectionProps): React.JSX.Element {
 	return (
 		<Container background="gray6" height="fill" mainAlignment="flex-start">
 			<SectionHeader

--- a/src/settings/components/shared/sidebar-navigation.tsx
+++ b/src/settings/components/shared/sidebar-navigation.tsx
@@ -17,6 +17,8 @@ import {
 } from '@zextras/carbonio-design-system';
 import styled from 'styled-components';
 
+import { Tab } from '../../types';
+
 const LinkText = styled(Text)`
 	user-select: none;
 `;
@@ -31,7 +33,15 @@ const NavigationLink = styled(Row)`
 	}
 `;
 
-export function SidebarNavigation({ links, activeTab, setActiveTab }): React.JSX.Element {
+export function SidebarNavigation({
+	links,
+	activeTab,
+	setActiveTab
+}: {
+	links: Tab[];
+	activeTab: Tab;
+	setActiveTab: (activeTab: Tab) => void;
+}): React.JSX.Element {
 	return (
 		<Container width="100%" height="100%" mainAlignment="flex-start" crossAlignment="stretch">
 			{links.map((link, index: number) => (

--- a/src/settings/components/shared/sidebar-navigation.tsx
+++ b/src/settings/components/shared/sidebar-navigation.tsx
@@ -1,12 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
 import React from 'react';
 
-import { Container, Divider, Icon, Padding, Row, Text } from '@zextras/carbonio-design-system';
+import {
+	Container,
+	Divider,
+	Icon,
+	Padding,
+	Row,
+	Text,
+	Theme
+} from '@zextras/carbonio-design-system';
 import styled from 'styled-components';
 
 const LinkText = styled(Text)`
@@ -14,24 +22,26 @@ const LinkText = styled(Text)`
 `;
 const NavigationLink = styled(Row)`
 	cursor: pointer;
-	background: ${({ theme, isActive }) => isActive && theme.palette.highlight.regular};
+	background: ${({ theme, isActive }: { theme: Theme; isActive: boolean }): string | false =>
+		isActive && theme.palette.highlight.regular};
 	transition: 0.2s ease-out;
 	&:hover {
-		background: ${({ theme, isActive }) => theme.palette[isActive ? 'highlight' : 'gray5'].hover};
+		background: ${({ theme, isActive }: { theme: Theme; isActive: boolean }): string =>
+			theme.palette[isActive ? 'highlight' : 'gray5'].hover};
 	}
 `;
 
-export function SidebarNavigation({ links, activeTab, setActiveTab }) {
+export function SidebarNavigation({ links, activeTab, setActiveTab }): React.JSX.Element {
 	return (
 		<Container width="100%" height="100%" mainAlignment="flex-start" crossAlignment="stretch">
-			{links.map((link, index) => (
+			{links.map((link, index: number) => (
 				<div key={index}>
 					{index !== 0 && <Divider color="gray3" />}
 					<NavigationLink
 						width="100%"
 						padding={{ horizontal: 'large', vertical: 'medium' }}
 						mainAlignment="flex-start"
-						onClick={() => setActiveTab(link)}
+						onClick={(): void => setActiveTab(link)}
 						isActive={activeTab.name === link.name}
 					>
 						{link.icon && (

--- a/src/settings/components/shared/sidebar-navigation.tsx
+++ b/src/settings/components/shared/sidebar-navigation.tsx
@@ -54,14 +54,7 @@ export function SidebarNavigation({
 						onClick={(): void => setActiveTab(link)}
 						isActive={activeTab.name === link.name}
 					>
-						{link.icon && (
-							<Padding right="large">
-								<Icon size="large" icon={link.icon} />
-							</Padding>
-						)}
-						<LinkText size="large" isActive={activeTab.name === link.name}>
-							{link.label}
-						</LinkText>
+						<LinkText size="large">{link.label}</LinkText>
 					</NavigationLink>
 				</div>
 			))}

--- a/src/settings/network/fetchSoap.ts
+++ b/src/settings/network/fetchSoap.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-export const fetchSoap = (api, body) =>
+export const fetchSoap = (api: string, body: Record<string, any>): Promise<any> =>
 	fetch(`/service/soap/${api}`, {
 		method: 'POST',
 		headers: {

--- a/src/settings/test/auth-view.test.tsx
+++ b/src/settings/test/auth-view.test.tsx
@@ -21,6 +21,7 @@ jest.mock('@zextras/carbonio-shell-ui', () => ({
 jest.mock('../network/checkSupportedZextras', () => ({
 	checkSupportedZextras: jest.fn()
 }));
+
 describe('auth view', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -70,5 +71,50 @@ describe('auth view', () => {
 		expect(
 			within(screen.getByTestId('active-panel')).getByText('settingsAuth.Displayer.ResetPassword')
 		).toBeInTheDocument();
+	});
+
+	it('should display EAS, OTP and Mobile APP if advanced supported', async () => {
+		(checkSupportedZextras as jest.Mock).mockResolvedValue({ isSupported: true });
+		(useUserSettings as jest.Mock).mockReturnValue({
+			attrs: {
+				carbonioFeatureOTPMgmtEnabled: 'TRUE',
+				zimbraFeatureResetPasswordStatus: 'disabled'
+			}
+		});
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				Body: { response: { values: [] } }
+			})
+		);
+
+		await act(async () => {
+			customRender(<App />);
+		});
+
+		expect(screen.getByText('easAuth.label')).toBeVisible();
+		expect(screen.getByText('appMobile.title')).toBeVisible();
+		expect(screen.getByText('setNewOtpLabel.title')).toBeVisible();
+	});
+	it('should not display EAS, OTP and Mobile APP if advanced not supported', async () => {
+		(checkSupportedZextras as jest.Mock).mockResolvedValue({ isSupported: false });
+		(useUserSettings as jest.Mock).mockReturnValue({
+			attrs: {
+				carbonioFeatureOTPMgmtEnabled: 'TRUE',
+				zimbraFeatureResetPasswordStatus: 'disabled'
+			}
+		});
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				Body: { response: { values: [] } }
+			})
+		);
+
+		await act(async () => {
+			customRender(<App />);
+		});
+
+		expect(screen.queryByText('easAuth.label')).not.toBeInTheDocument();
+		expect(screen.queryByText('appMobile.title')).not.toBeInTheDocument();
+		expect(screen.queryByText('setNewOtpLabel.title')).not.toBeInTheDocument();
 	});
 });

--- a/src/settings/test/auth-view.test.tsx
+++ b/src/settings/test/auth-view.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { act, render, screen, within } from '@testing-library/react';
+import { ThemeProvider } from '@zextras/carbonio-design-system';
+import i18next, { i18n } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import App from '../auth-view';
+import fetchMock from 'jest-fetch-mock';
+
+import { checkSupportedZextras } from '../network/checkSupportedZextras';
+
+export function getAppI18n(): i18n {
+	const newI18n = i18next.createInstance();
+	newI18n.init({
+		lng: 'en',
+		fallbackLng: 'en',
+		debug: false,
+		interpolation: {
+			escapeValue: false
+		},
+		resources: { en: { translation: {} } }
+	});
+	return newI18n;
+}
+
+jest.mock('@zextras/carbonio-shell-ui', () => ({
+	useUserSettings: (): any => ({
+		attrs: {
+			carbonioFeatureOTPMgmtEnabled: 'TRUE',
+			zimbraFeatureResetPasswordStatus: undefined
+		}
+	}),
+	t: (key: string): any => key
+}));
+
+jest.mock('../network/checkSupportedZextras', () => ({
+	checkSupportedZextras: jest.fn()
+}));
+
+describe('auth view', () => {
+	it('should set change password as active by default when zimbraFeatureResetPasswordStatus is NOT enabled', async () => {
+		(checkSupportedZextras as jest.Mock).mockResolvedValue({ isSupported: true });
+
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				Body: { response: { values: [] } }
+			})
+		);
+
+		await act(async () => {
+			render(
+				<ThemeProvider>
+					<I18nextProvider i18n={getAppI18n()}>
+						<App />
+					</I18nextProvider>
+				</ThemeProvider>
+			);
+		});
+
+		expect(
+			within(screen.getByTestId('active-panel')).getByText('changePassword.instruction')
+		).toBeInTheDocument();
+	});
+});

--- a/src/settings/test/auth-view.test.tsx
+++ b/src/settings/test/auth-view.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 
 import { act, screen, within } from '@testing-library/react';
+import { useUserSettings } from '@zextras/carbonio-shell-ui';
 import fetchMock from 'jest-fetch-mock';
 
 import { customRender } from '../../test/test-utils';
@@ -13,23 +14,26 @@ import App from '../auth-view';
 import { checkSupportedZextras } from '../network/checkSupportedZextras';
 
 jest.mock('@zextras/carbonio-shell-ui', () => ({
-	useUserSettings: (): any => ({
-		attrs: {
-			carbonioFeatureOTPMgmtEnabled: 'TRUE',
-			zimbraFeatureResetPasswordStatus: undefined
-		}
-	}),
+	useUserSettings: jest.fn(),
 	t: (key: string): any => key
 }));
 
 jest.mock('../network/checkSupportedZextras', () => ({
 	checkSupportedZextras: jest.fn()
 }));
-
 describe('auth view', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it('should set change password as active by default when zimbraFeatureResetPasswordStatus is NOT enabled', async () => {
 		(checkSupportedZextras as jest.Mock).mockResolvedValue({ isSupported: true });
-
+		(useUserSettings as jest.Mock).mockReturnValue({
+			attrs: {
+				carbonioFeatureOTPMgmtEnabled: 'TRUE',
+				zimbraFeatureResetPasswordStatus: 'disabled'
+			}
+		});
 		fetchMock.mockResponseOnce(
 			JSON.stringify({
 				Body: { response: { values: [] } }
@@ -42,6 +46,29 @@ describe('auth view', () => {
 
 		expect(
 			within(screen.getByTestId('active-panel')).getByText('changePassword.instruction')
+		).toBeInTheDocument();
+	});
+
+	it('should set reset password as active by default when zimbraFeatureResetPasswordStatus is enabled', async () => {
+		(checkSupportedZextras as jest.Mock).mockResolvedValue({ isSupported: true });
+		(useUserSettings as jest.Mock).mockReturnValue({
+			attrs: {
+				carbonioFeatureOTPMgmtEnabled: 'TRUE',
+				zimbraFeatureResetPasswordStatus: 'enabled'
+			}
+		});
+		fetchMock.mockResponseOnce(
+			JSON.stringify({
+				Body: { response: { values: [] } }
+			})
+		);
+
+		await act(async () => {
+			customRender(<App />);
+		});
+
+		expect(
+			within(screen.getByTestId('active-panel')).getByText('settingsAuth.Displayer.ResetPassword')
 		).toBeInTheDocument();
 	});
 });

--- a/src/settings/test/auth-view.test.tsx
+++ b/src/settings/test/auth-view.test.tsx
@@ -5,28 +5,12 @@
  */
 import React from 'react';
 
-import { act, render, screen, within } from '@testing-library/react';
-import { ThemeProvider } from '@zextras/carbonio-design-system';
-import i18next, { i18n } from 'i18next';
-import { I18nextProvider } from 'react-i18next';
-import App from '../auth-view';
+import { act, screen, within } from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 
+import { customRender } from '../../test/test-utils';
+import App from '../auth-view';
 import { checkSupportedZextras } from '../network/checkSupportedZextras';
-
-export function getAppI18n(): i18n {
-	const newI18n = i18next.createInstance();
-	newI18n.init({
-		lng: 'en',
-		fallbackLng: 'en',
-		debug: false,
-		interpolation: {
-			escapeValue: false
-		},
-		resources: { en: { translation: {} } }
-	});
-	return newI18n;
-}
 
 jest.mock('@zextras/carbonio-shell-ui', () => ({
 	useUserSettings: (): any => ({
@@ -53,13 +37,7 @@ describe('auth view', () => {
 		);
 
 		await act(async () => {
-			render(
-				<ThemeProvider>
-					<I18nextProvider i18n={getAppI18n()}>
-						<App />
-					</I18nextProvider>
-				</ThemeProvider>
-			);
+			customRender(<App />);
 		});
 
 		expect(

--- a/src/settings/types/index.ts
+++ b/src/settings/types/index.ts
@@ -4,14 +4,25 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-export type PasswordId = string;
+import React from 'react';
 
+export type PasswordId = string;
 export type Password = {
-	created: number;
 	id: PasswordId;
 	label: string;
 	enabled: boolean;
 	services: [{ service: string }];
+	created: number;
+};
+
+export type OtpId = string;
+
+export type Otp = {
+	id: OtpId;
+	label: string;
+	enabled: boolean;
+	failed_attempts: number;
+	created: number;
 };
 
 export type ViewProps = { passwords: Password[]; setPasswords: (password: Password[]) => void };
@@ -19,5 +30,11 @@ export type ViewProps = { passwords: Password[]; setPasswords: (password: Passwo
 export type TableRow = {
 	id: string;
 	columns: [string, string, string, string];
+	clickable: boolean;
+};
+
+export type OtpTableRow = {
+	id: string;
+	columns: [string, string, React.JSX.Element, string];
 	clickable: boolean;
 };

--- a/src/settings/types/index.ts
+++ b/src/settings/types/index.ts
@@ -38,3 +38,14 @@ export type OtpTableRow = {
 	columns: [string, string, React.JSX.Element, string];
 	clickable: boolean;
 };
+
+export type Tab = {
+	name: string;
+	label: string;
+	view: (props?: {
+		passwords: Password[];
+		setPasswords: (passwords: Password[]) => void;
+	}) => React.JSX.Element;
+	instruction: string;
+	link?: string;
+};

--- a/src/settings/types/index.ts
+++ b/src/settings/types/index.ts
@@ -38,14 +38,15 @@ export type OtpTableRow = {
 	columns: [string, string, React.JSX.Element, string];
 	clickable: boolean;
 };
+type TabViewWithPasswords = {
+	passwords: Password[];
+	setPasswords: (passwords: Password[]) => void;
+};
 
 export type Tab = {
 	name: string;
 	label: string;
-	view: (props: {
-		passwords: Password[];
-		setPasswords: (passwords: Password[]) => void;
-	}) => React.JSX.Element | (() => React.JSX.Element);
+	view: React.FC<TabViewWithPasswords> | React.FC;
 	instruction: string;
 	link?: string;
 };

--- a/src/settings/types/index.ts
+++ b/src/settings/types/index.ts
@@ -42,10 +42,10 @@ export type OtpTableRow = {
 export type Tab = {
 	name: string;
 	label: string;
-	view: (props?: {
+	view: (props: {
 		passwords: Password[];
 		setPasswords: (passwords: Password[]) => void;
-	}) => React.JSX.Element;
+	}) => React.JSX.Element | (() => React.JSX.Element);
 	instruction: string;
 	link?: string;
 };

--- a/src/settings/types/index.ts
+++ b/src/settings/types/index.ts
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export type PasswordId = string;
+
+export type Password = {
+	created: number;
+	id: PasswordId;
+	label: string;
+	enabled: boolean;
+	services: [{ service: string }];
+};
+
+export type ViewProps = { passwords: Password[]; setPasswords: (password: Password[]) => void };
+
+export type TableRow = {
+	id: string;
+	columns: [string, string, string, string];
+	clickable: boolean;
+};

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { ThemeProvider } from '@zextras/carbonio-design-system';
+import i18next, { i18n } from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+
+function getAppI18n(): i18n {
+	const newI18n = i18next.createInstance();
+	newI18n.init({
+		lng: 'en',
+		fallbackLng: 'en',
+		debug: false,
+		interpolation: {
+			escapeValue: false
+		},
+		resources: { en: { translation: {} } }
+	});
+	return newI18n;
+}
+export function customRender(component: React.JSX.Element): ReturnType<typeof render> {
+	return render(
+		<ThemeProvider>
+			<I18nextProvider i18n={getAppI18n()}>{component}</I18nextProvider>
+		</ThemeProvider>
+	);
+}


### PR DESCRIPTION
The module needs to be refactored to ts, however there were some weird and improper usages that seem not to have any effect in current code (e.g.: passing undefined values), so in some cases we removed properties.
**We focused on auth settings and its views/tabs (EAS, OTP, etc.)**

To avoid too much confusion we decided to do the conversion to ts, one step at a time, so the PRs will be small and easier to understand.

We added also a test that shows EAS, OTP and Mobile settings are not shown when advanced is not installed/supported (See: #99 )