### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
     ])
 )
 
-zappPipeline()
+uiPipeline()


### PR DESCRIPTION
## Summary

`jenkins-lib-ui` has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function is now available directly from `jenkins-lib-common` starting at version `v2.4.3`.

## Changes

- Replaced the `jenkins-lib-ui@1.0.13` library reference with `jenkins-lib-common@v2.4.3`
- Updated the remote URL from `jenkins-lib-ui.git` to `jenkins-lib-common.git`
- Renamed `zappPipeline()` call to `uiPipeline()` (parameters are identical)

## Notes

No functional change — `uiPipeline()` in `jenkins-lib-common` is a drop-in replacement for the old `zappPipeline()` from `jenkins-lib-ui`.